### PR TITLE
Switch app-building base image to rust-lang:nightly-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:9-slim AS base
 WORKDIR /data-server
 RUN apt update && apt install -qy ca-certificates openssl libssl-dev zlib1g-dev
 
-FROM rust-lang:nightly-slim AS rust-build-deps
+FROM rustlang/rust:nightly-slim AS rust-build-deps
 
 ADD Cargo.toml Cargo.lock /data-server/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM debian:9-slim AS base
 
-WORKDIR /data-server
-RUN apt update && apt install -qy ca-certificates openssl libssl-dev zlib1g-dev
+RUN apt update && apt install -qy ca-certificates openssl zlib1g
 
-FROM rustlang/rust:nightly-slim AS rust-build-deps
+FROM rustlang/rust:nightly-slim AS rust-build
+
+RUN apt update && apt install -qy libssl-dev openssl pkg-config zlib1g-dev
+
+WORKDIR /data-server
 
 ADD Cargo.toml Cargo.lock /data-server/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,7 @@ FROM debian:9-slim AS base
 WORKDIR /data-server
 RUN apt update && apt install -qy ca-certificates openssl libssl-dev zlib1g-dev
 
-FROM base as rust-build-deps
-
-RUN apt update && apt install -qy autoconf automake bash cmake curl make pkg-config
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
-
-RUN echo "test -f \$HOME/.cargo/env && source \$HOME/.cargo/env" >> /etc/profile \
-    && echo "test -f \$HOME/.cargo/env && source \$HOME/.cargo/env" >> /etc/bash.bashrc
-
-CMD /bin/bash
-
-FROM rust-build-deps AS rust-build
+FROM rust-lang:nightly-slim AS rust-build-deps
 
 ADD Cargo.toml Cargo.lock /data-server/
 


### PR DESCRIPTION
Resolves #13, if we decide to do this.

PR is currently open to collect timing information.

---

This PR switches to the semi-official automatic nightly rust images, from https://hub.docker.com/r/rustlang/rust/tags (powered by https://github.com/rust-lang-nursery/docker-rust-nightly).