### PR TITLE
Mocking, Part II

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,13 @@ version = "0.0.0-alpha.0"
 
 [dependencies]
 git2 = "0.7"
-mocktopus = "0.5"
 rocket = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+
+[dev-dependencies]
+mocktopus = "0.5"
 
 [lib]
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(decl_macro, proc_macro_hygiene, uniform_paths)]
+#![feature(custom_attribute, decl_macro, proc_macro_hygiene, uniform_paths)]
 
 #[macro_use]
 extern crate rocket;
@@ -6,6 +6,10 @@ extern crate rocket;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(test)]
+extern crate mocktopus;
+
+#[cfg_attr(test, mockable)]
 pub mod routes;
 
 use routes::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@ extern crate mocktopus;
 #[cfg_attr(test, mockable)]
 pub mod routes;
 
-use routes::*;
-
 /// Prepares a rocket::Rocket for usage.
 ///
 /// # Examples
@@ -23,5 +21,5 @@ use routes::*;
 /// let rocket: rocket::Rocket = server();
 /// ```
 pub fn server() -> rocket::Rocket {
-	rocket::ignite().mount("/", routes![healthz, ping])
+	rocket::ignite().mount("/", routes![routes::healthz::healthz, routes::ping::ping])
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,2 +1,5 @@
+#[cfg_attr(test, mockable)]
 pub mod healthz;
+
+#[cfg_attr(test, mockable)]
 pub mod ping;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,4 +1,2 @@
 pub mod healthz;
 pub mod ping;
-pub use healthz::*;
-pub use ping::*;

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -2,9 +2,9 @@ use rocket::http::ContentType;
 use rocket::response::{Response, Result};
 use std::io::Cursor;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Health {
-	code: bool,
+	pub code: bool,
 }
 
 pub fn get_health() -> Health {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -7,4 +7,5 @@ extern crate data_server;
 #[cfg(test)]
 extern crate mocktopus;
 
+// Add a `mod` for each test directory with a mod.rs in it.
 mod routes;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -4,4 +4,7 @@
 extern crate rocket;
 extern crate data_server;
 
+#[cfg(test)]
+extern crate mocktopus;
+
 mod routes;

--- a/tests/routes/healthz.rs
+++ b/tests/routes/healthz.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use data_server::routes::healthz::*;
+
 #[test]
 fn responds_with_correct_headers() {
 	let rocket = rocket::ignite().mount("/", routes![healthz]);

--- a/tests/routes/healthz.rs
+++ b/tests/routes/healthz.rs
@@ -5,7 +5,7 @@ use data_server::routes::healthz::*;
 
 #[test]
 fn when_healthy_responds_healthily() {
-	routes::healthz::get_health.mock_safe(|| MockResult::Return(Health { code: true }));
+	healthz::get_health.mock_safe(|| MockResult::Return(Health { code: true }));
 
 	let rocket = rocket::ignite().mount("/", routes![healthz]);
 	let client = Client::new(rocket).expect("valid rocket instance");

--- a/tests/routes/healthz.rs
+++ b/tests/routes/healthz.rs
@@ -5,8 +5,7 @@ use data_server::routes::healthz::*;
 
 #[test]
 fn when_healthy_responds_healthily() {
-	use data_server::routes::healthz::Health;
-	data_server::routes::healthz::get_health.mock_safe(|| MockResult::Return(Health { code: true }));
+	routes::healthz::get_health.mock_safe(|| MockResult::Return(Health { code: true }));
 
 	let rocket = rocket::ignite().mount("/", routes![healthz]);
 	let client = Client::new(rocket).expect("valid rocket instance");

--- a/tests/routes/healthz.rs
+++ b/tests/routes/healthz.rs
@@ -1,6 +1,24 @@
 use super::*;
+use mocktopus::mocking::*;
 
 use data_server::routes::healthz::*;
+
+#[test]
+fn when_healthy_responds_healthily() {
+	use data_server::routes::healthz::Health;
+	data_server::routes::healthz::get_health.mock_safe(|| MockResult::Return(Health { code: true }));
+
+	let rocket = rocket::ignite().mount("/", routes![healthz]);
+	let client = Client::new(rocket).expect("valid rocket instance");
+	let mut response = client.get("/healthz").dispatch();
+
+	assert_eq!(response.status(), Status::Ok);
+
+	let response: String = response.body_string().unwrap();
+	let response: Health = serde_json::from_str(&response).unwrap();
+
+	assert_eq!(response.code, true);
+}
 
 #[test]
 fn responds_with_correct_headers() {

--- a/tests/routes/mod.rs
+++ b/tests/routes/mod.rs
@@ -3,5 +3,11 @@
 use rocket::http::Status;
 use rocket::local::Client;
 
+// In order to get your test module to run, you need to add a mod <file.rs>.
+// Note that .rs files in this directory are each given their own "module" that
+// is named appropriately, so by adding a .rs file you add a module.  You
+// should really like that.
+//
+// Adding `mod` <filename sans .rs> will do.
 mod healthz;
 mod ping;

--- a/tests/routes/mod.rs
+++ b/tests/routes/mod.rs
@@ -3,7 +3,5 @@
 use rocket::http::Status;
 use rocket::local::Client;
 
-use data_server::routes::*;
-
 mod healthz;
 mod ping;

--- a/tests/routes/ping.rs
+++ b/tests/routes/ping.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use data_server::routes::ping::*;
+
 #[test]
 fn responds_with_pong() {
 	let rocket = rocket::ignite().mount("/", routes![ping]);


### PR DESCRIPTION
This PR moves forward with an even better mocking strategy.

- Moves `mocktopus` out as a `dev-dependency`.
- Flattens out module hierarchy to prevent possible module-name short-circuits. (Rust has safeguards against them, but I'd rather avoid confusing it and be more explicit.)
- Adjusts the `Health` struct to be deserializable and have `code` as a `pub` field.
- Adds another test on the `healthz` route that mocks the `get_health` function and checks the output of the route.