### PR TITLE
lib: Drop uniform_paths feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(custom_attribute, decl_macro, proc_macro_hygiene, uniform_paths)]
+#![feature(custom_attribute, decl_macro, proc_macro_hygiene)]
 
 #[macro_use]
 extern crate rocket;


### PR DESCRIPTION
This feature was stabilized in Rust 2018, and we don't need it to be explicitly enabled anymore.  (This commit is intended primarily to get rid of a compilation warning.)