### PR TITLE
cargo: Use rye-vendored Mocktopus distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
       - clippy
       - test
       - compile:
-          requires: [ rustfmt, test, clippy ]
+          requires: [ rustfmt, test ]
       - docker-build:
           requires: [ compile ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = "1.0"
 [dev-dependencies]
 mocktopus = "0.5"
 
+[patch.crates-io]
+mocktopus = { git = "https://github.com/rye/Mocktopus" }
+
 [lib]
 path = "src/lib.rs"
 


### PR DESCRIPTION
I have not seen or heard any activity from the maintainer of Mocktopus in the last month, and there are a number of breaking issues on the nightly end.  This commit should make the code compile and test nicely again after a feature stabilized in the nightly that broke Mocktopus' code (`get_test_id` -> `test_id` with no deprecation), and moves us away from the upstream dependency, hopefully temporarily.