### PR TITLE
cargo: Update mocktopus to version 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 name = "data_server"
 version = "0.0.0-alpha.0"
 dependencies = [
- "mocktopus 0.5.0 (git+https://github.com/rye/Mocktopus)",
+ "mocktopus 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -197,15 +197,15 @@ dependencies = [
 
 [[package]]
 name = "mocktopus"
-version = "0.5.0"
-source = "git+https://github.com/rye/Mocktopus#b803b0005aca6a711afa8e8e7a763fcb9c138696"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "mocktopus_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mocktopus_macros 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mocktopus_macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,8 +539,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mocktopus 0.5.0 (git+https://github.com/rye/Mocktopus)" = "<none>"
-"checksum mocktopus_macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c1e0b938fdd9eaf98b023d6f4068b5ae4c931332fe76825ca9ad2630a3ee0c1"
+"checksum mocktopus 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f44c1c0a8b506aa0ff1f3fce618929bd8b09b00596fae7a973ebad1848544c4d"
+"checksum mocktopus_macros 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77f34f37caa604f8fc714e33da267ffe191e9a6b0536c27c3b35dc87c2d4e169"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c26d2b92e47063ffce70d3e3b1bd097af121a9e0db07ca38a6cc1cf0cc85ff25"
 "checksum pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "336db4a192cc7f54efeb0c4e11a9245394824cc3bcbd37ba3ff51240c35d7a6e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-mocktopus = "0.5"
-
-[patch.crates-io]
-mocktopus = { git = "https://github.com/rye/Mocktopus" }
+mocktopus = "0.6"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
(And remove cargo patch switching to use my fork.)