### PR TITLE
Cleanup dependency setup and how we include serde_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ dependencies = [
  "mocktopus 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -349,6 +348,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ version = "0.0.0-alpha.0"
 
 [dependencies]
 rocket = "0.4.1"
-serde = "1.0.92"
-serde_derive = "1.0.92"
+serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.39"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,13 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-rocket = "0.4"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+rocket = "0.4.1"
+serde = "1.0.92"
+serde_derive = "1.0.92"
+serde_json = "1.0.39"
 
 [dev-dependencies]
-mocktopus = "0.7"
+mocktopus = "0.7.0"
 
 [lib]
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate rocket;
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 #[cfg(test)]
 extern crate mocktopus;


### PR DESCRIPTION
This is aimed at reducing the number of PRs we get from dependabot for Serde updates to just one instead of two.